### PR TITLE
Do not pass --update to apk as it saves a local copy of the index even if we specify --no-cache.

### DIFF
--- a/kafka-rest/Dockerfile
+++ b/kafka-rest/Dockerfile
@@ -9,10 +9,10 @@ ENV PATH=$PATH:$KAFKA_HOME/bin
 
 RUN set -ex; \
     WORKDIR="$PWD"; \
-    apk --no-cache --update add ca-certificates curl gnupg bash; \
+    apk --no-cache add gnupg; \
     PATH=$PATH:/opt/maven/bin; \
     mkdir -p /opt/maven; \
-	  curl -q -sSLO  "http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz"; \
+    curl -q -sSLO  "http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz"; \
     curl -q -sSLO  "http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz.asc"; \
     curl -q -sSLO  "http://archive.apache.org/dist/maven/KEYS"; \
     export GNUPGHOME="$(mktemp -d)"; \

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -15,7 +15,7 @@ ENV PATH=$PATH:$KAFKA_HOME/bin
 
 RUN set -ex; \
     WORKDIR="$PWD"; \
-    apk --no-cache --update add ca-certificates curl gnupg bash; \
+    apk --no-cache add gnupg; \
     curl -q -sSLO "http://www.apache.org/dist/kafka/$KAFKA_VERSION/$KAFKA_DIST.tgz"; \
     curl -q -sSLO "http://www.apache.org/dist/kafka/$KAFKA_VERSION/$KAFKA_DIST.tgz.asc"; \
     curl -q -sSLO "http://kafka.apache.org/KEYS"; \

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -18,8 +18,7 @@ ENV KEYCLOAK_HOME=$KEYCLOAK_HOME \
 
 RUN set -ex; \
     WORKDIR="$PWD"; \
-    apk --no-cache --update add ca-certificates curl bash; \
-	  curl -q -sSLO  "https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz"; \
+    curl -q -sSLO  "https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz"; \
     curl -q -sSLO  "https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz.md5"; \
     echo "$(cat keycloak-$KEYCLOAK_VERSION.tar.gz.md5)  keycloak-$KEYCLOAK_VERSION.tar.gz" | md5sum -c; \
     mkdir -p "$KEYCLOAK_HOME"; \

--- a/zookeeper/Dockerfile
+++ b/zookeeper/Dockerfile
@@ -19,7 +19,7 @@ ENV ZK_USER=$ZK_USER \
 RUN set -ex; \
     WORKDIR="$PWD"; \
     # netcat-openbsd is used by the zkOk.sh and zkMetrics.sh scripts
-    apk --no-cache --update add ca-certificates netcat-openbsd curl bash; \
+    apk --no-cache add netcat-openbsd ; \
     curl -q -sSLO "http://www.apache.org/dist/zookeeper/$ZK_DIST/$ZK_DIST.tar.gz"; \
     echo "$SHA1_KEY  $ZK_DIST.tar.gz" | sha1sum -c; \
     mkdir -p "$ZK_INSTALL_DIR"; \


### PR DESCRIPTION

Also, do not install ca-certificates curl or bash on images based on nearpod/alpine-jvm as these were installed by our base image.